### PR TITLE
Support both RFC2045 & non-RFC2045 base64 encodings

### DIFF
--- a/pysigma/signatures.py
+++ b/pysigma/signatures.py
@@ -28,9 +28,16 @@ SUPPORTED_MODIFIERS = {
     # 're',
 }
 
+
+def decode_base64(x: str) -> str:
+    # support both RFC 2045 style encoding & non-RFC 2045 style encoding
+    x = x.replace("\n", "")
+    return base64.b64encode(x.encode()).decode()
+
+
 MODIFIER_FUNCTIONS = {
     'contains': lambda x: f'.*{x}.*',
-    'base64': lambda x: base64.encodebytes(x.encode()).decode(),
+    'base64': lambda x: decode_base64(x),
     'endswith': lambda x: f'.*{x}$',
     'startswith': lambda x: f'^{x}.*',
 }

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,3 +1,5 @@
+import base64
+
 from pysigma import PySigma
 from pysigma.signatures import sigma_string_to_regex
 
@@ -245,3 +247,18 @@ def test_all_of_x():
     assert len(sigma.check_events([{'log': '1ab ba ca', 'Data': []}])) == 0
     assert len(sigma.check_events([{'log': 'ba', 'Data': []}])) == 0
     assert len(sigma.check_events([{'log': 'aabb', 'Data': []}])) == 1
+
+
+def test_base64():
+    sigma = PySigma()
+    sigma.add_signature("""
+        title: sample signature
+        detection:
+            base64:
+              a|base64: foo
+            condition: base64
+    """)
+
+    assert len(sigma.check_events([{"a": base64.b64encode(b"foo").decode()}])) == 1
+    assert len(sigma.check_events([{"a": base64.encodebytes(b"foo").decode()}])) == 1
+    assert len(sigma.check_events([{"a": "foo"}])) == 0


### PR DESCRIPTION
Hi, first of all, thank you for creating this library.

I think there is a room to improve about the base64 modifier function.
The current implementation supports RFC2045 style base64 encoding and it does not support non-RFC2045 style base64 encoding.
I think it will be better to support both.

Note: In the official spec, base64 encoding style is not specified.
https://github.com/SigmaHQ/sigma/wiki/Specification#transformations