### PR TITLE
refactor: use lark v1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 clint
-lark-parser
+lark >= 1.1.7, < 2.0
 xmltodict
 PyYAML
 evtx


### PR DESCRIPTION
Change to use `lark` instead of `lark-parser`.

Lark renamed its default package name as `lark` since v1.0. 

> Install lark using pip install lark (instead of lark-parser ).
>
> --- https://github.com/lark-parser/lark/releases/tag/1.0.0

This PR makes enable to use the latest lark. 
There is no compatible issue and performance issue with the latest lark as far as I confirmed.
