### PR TITLE
specify build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "PyYAML", "GitPython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
use pyproject.toml to specify build dependencies and fix pip install in clean environments