### PR TITLE
Add base64offset modifier

### DIFF
--- a/pysigma/signatures.py
+++ b/pysigma/signatures.py
@@ -23,7 +23,7 @@ SUPPORTED_MODIFIERS = {
     'contains',
     'all',
     'base64',
-    'base64offset'
+    'base64offset',
     'endswith',
     'startswith',
     # 'utf16le',

--- a/pysigma/signatures.py
+++ b/pysigma/signatures.py
@@ -34,7 +34,7 @@ SUPPORTED_MODIFIERS = {
 }
 
 
-def decode_base64(x: str) -> str:
+def apply_base64_modifier(x: str) -> str:
     # support both RFC 2045 style encoding & non-RFC 2045 style encoding
     x = x.replace("\n", "")
     return base64.b64encode(x.encode()).decode()
@@ -60,7 +60,7 @@ def apply_base64offset_modifier(x: str) -> str:
 
 MODIFIER_FUNCTIONS = {
     'contains': lambda x: f'.*{x}.*',
-    'base64': lambda x: decode_base64(x),
+    'base64': lambda x: apply_base64_modifier(x),
     "base64offset": lambda x: apply_base64offset_modifier(x),
     'endswith': lambda x: f'.*{x}$',
     'startswith': lambda x: f'^{x}.*',

--- a/pysigma/signatures.py
+++ b/pysigma/signatures.py
@@ -12,9 +12,9 @@ from .parser import prepare_condition
 class SignatureLoadError(KeyError):
     pass
 
-class PatchedSafeLoader(yaml.SafeLoader):     
+class PatchedSafeLoader(yaml.SafeLoader):
     yaml_implicit_resolvers = yaml.SafeLoader.yaml_implicit_resolvers.copy()
-    
+
     # Avoid auto-resolution to "tag:yaml.org,2002:value" when encountering '='
     yaml_implicit_resolvers.pop('=')
 
@@ -23,7 +23,7 @@ SUPPORTED_MODIFIERS = {
     'contains',
     'all',
     'base64',
-    # 'base64offset'
+    'base64offset'
     'endswith',
     'startswith',
     # 'utf16le',
@@ -39,10 +39,29 @@ def decode_base64(x: str) -> str:
     x = x.replace("\n", "")
     return base64.b64encode(x.encode()).decode()
 
+def apply_base64offset_modifier(x: str) -> str:
+    # modified from https://github.com/SigmaHQ/pySigma
+    # (https://github.com/SigmaHQ/pySigma/blob/main/sigma/modifiers.py: SigmaBase64OffsetModifier)
+    x = x.replace("\n", "")
+
+    start_offsets = (0, 2, 3)
+    end_offsets = (None, -3, -2)
+
+    offsets: list[str] = []
+    for i in range(3):
+        offsets.append(
+            base64.b64encode(i * b" " + x.encode())[
+                start_offsets[i] : end_offsets[(len(x) + i) % 3]
+            ].decode()
+        )
+
+    return f"({'|'.join(offsets)})"
+
 
 MODIFIER_FUNCTIONS = {
     'contains': lambda x: f'.*{x}.*',
     'base64': lambda x: decode_base64(x),
+    "base64offset": lambda x: apply_base64offset_modifier(x),
     'endswith': lambda x: f'.*{x}$',
     'startswith': lambda x: f'^{x}.*',
 }

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -262,3 +262,19 @@ def test_base64():
     assert len(sigma.check_events([{"a": base64.b64encode(b"foo").decode()}])) == 1
     assert len(sigma.check_events([{"a": base64.encodebytes(b"foo").decode()}])) == 1
     assert len(sigma.check_events([{"a": "foo"}])) == 0
+
+
+def test_base64offset():
+    sigma = PySigma()
+    sigma.add_signature("""
+        title: sample signature
+        detection:
+            base64offset:
+              a|base64offset: /bin/bash
+            condition: base64offset
+    """)
+    # ref. https://sigmahq.io/docs/basics/modifiers.html#base64-base64offset
+    assert len(sigma.check_events([{"a": "L2Jpbi9iYXNo"}])) == 1
+    assert len(sigma.check_events([{"a": "9iaW4vYmFza"}])) == 1
+    assert len(sigma.check_events([{"a": "vYmluL2Jhc2"}])) == 1
+    assert len(sigma.check_events([{"a": "foo"}])) == 0


### PR DESCRIPTION
This PR adds a support for base64offset modifier. 

This is a modification of the original [pysigma implementation](https://github.com/SigmaHQ/pySigma/blob/main/sigma/modifiers.py#L188-L212) but I think there is no license issue.